### PR TITLE
Modified PropertySortOrder to false

### DIFF
--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -88,7 +88,7 @@ linters:
     enabled: true
 
   PropertySortOrder:
-    enabled: true
+    enabled: false
 
   PropertySpelling:
     enabled: true


### PR DESCRIPTION
Modified `PropertySortOrder' to false to allow nest '.[class]' inside classes. Pending to solve in a better way.

Please review @nucliweb @PablitoGS @nguasch.
